### PR TITLE
Update baseimage and compile wget-lua with https support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ ENV HOME /root
 CMD ["/sbin/my_init"]
 
 # Install dependencies
-RUN apt-add-repository -y ppa:archiveteam/wget-lua
 RUN apt-get update
-RUN apt-get install -y python python-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget wget-lua
+RUN apt-get install -y python python-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget
+RUN ./get-wget-lua.sh
 
 # Fix dnsmasq bug (see https://github.com/nicolasff/docker-cassandra/issues/8#issuecomment-36922132)
 RUN echo 'user=root' >> /etc/dnsmasq.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ ENV HOME /root
 # Use baseimage-docker's init system.
 CMD ["/sbin/my_init"]
 
-# Install dependencies
-RUN apt-get update
-RUN apt-get install -y python python-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget libgnutls-dev liblua5.1-0-dev autoconf flex
 ADD get-wget-lua.sh /
-RUN chmod +x /get-wget-lua.sh && bash -c "/get-wget-lua.sh"
-RUN apt-get remove -y libgnutls-dev liblua5.1-0-dev autoconf flex && apt-get autoremove -y
+
+# Install dependencies
+RUN apt-get update && apt-get install -y python python-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget libgnutls-dev liblua5.1-0-dev autoconf flex \
+ && chmod +x /get-wget-lua.sh && bash -c "/get-wget-lua.sh" \
+ && apt-get remove -y libgnutls-dev liblua5.1-0-dev autoconf flex && apt-get clean && apt-get autoremove -y
 
 # Fix dnsmasq bug (see https://github.com/nicolasff/docker-cassandra/issues/8#issuecomment-36922132)
 RUN echo 'user=root' >> /etc/dnsmasq.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 # Use phusion/baseimage as base image.
 FROM phusion/baseimage:0.9.20
 
-MAINTAINER Filippo Valsorda <fv@filippo.io>
-
 # Set environment variables.
 ENV HOME /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use phusion/baseimage as base image.
-FROM phusion/baseimage:0.9.5
+FROM phusion/baseimage:0.9.20
 
 MAINTAINER Filippo Valsorda <fv@filippo.io>
 
@@ -10,9 +10,9 @@ ENV HOME /root
 CMD ["/sbin/my_init"]
 
 # Install dependencies
-RUN apt-get install -y python-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget
-RUN apt-add-repository -y ppa:archiveteam/wget-lua && apt-get update
-RUN apt-get install -y wget-lua
+RUN apt-add-repository -y ppa:archiveteam/wget-lua
+RUN apt-get update
+RUN apt-get install -y python python-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget wget-lua
 
 # Fix dnsmasq bug (see https://github.com/nicolasff/docker-cassandra/issues/8#issuecomment-36922132)
 RUN echo 'user=root' >> /etc/dnsmasq.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update
 RUN apt-get install -y python python-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget libgnutls-dev liblua5.1-0-dev autoconf flex
 ADD get-wget-lua.sh /
 RUN chmod +x /get-wget-lua.sh && bash -c "/get-wget-lua.sh"
+RUN apt-get remove -y libgnutls-dev liblua5.1-0-dev autoconf flex && apt-get autoremove -y
 
 # Fix dnsmasq bug (see https://github.com/nicolasff/docker-cassandra/issues/8#issuecomment-36922132)
 RUN echo 'user=root' >> /etc/dnsmasq.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ CMD ["/sbin/my_init"]
 
 # Install dependencies
 RUN apt-get update
-RUN apt-get install -y python python-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget
-RUN ./get-wget-lua.sh
+RUN apt-get install -y python python-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget libgnutls-dev liblua5.1-0-dev autoconf flex
+ADD get-wget-lua.sh /
+RUN bash -c "/get-wget-lua.sh"
 
 # Fix dnsmasq bug (see https://github.com/nicolasff/docker-cassandra/issues/8#issuecomment-36922132)
 RUN echo 'user=root' >> /etc/dnsmasq.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ CMD ["/sbin/my_init"]
 RUN apt-get update
 RUN apt-get install -y python python-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget libgnutls-dev liblua5.1-0-dev autoconf flex
 ADD get-wget-lua.sh /
-RUN bash -c "/get-wget-lua.sh"
+RUN chmod +x /get-wget-lua.sh && bash -c "/get-wget-lua.sh"
 
 # Fix dnsmasq bug (see https://github.com/nicolasff/docker-cassandra/issues/8#issuecomment-36922132)
 RUN echo 'user=root' >> /etc/dnsmasq.conf

--- a/get-wget-lua.sh
+++ b/get-wget-lua.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# This script downloads and compiles wget-lua.
+#
+
+# first, try to detect gnutls or openssl
+CONFIGURE_SSL_OPT=""
+if builtin type -p pkg-config &>/dev/null
+then
+  if pkg-config gnutls
+  then
+    echo "Compiling wget with GnuTLS."
+    CONFIGURE_SSL_OPT="--with-ssl=gnutls"
+  elif pkg-config openssl
+  then
+    echo "Compiling wget with OpenSSL."
+    CONFIGURE_SSL_OPT="--with-ssl=openssl"
+  fi
+fi
+
+WGET_DOWNLOAD_URL="http://warriorhq.archiveteam.org/downloads/wget-lua/wget-1.14.lua.LATEST.tar.bz2"
+
+rm -rf get-wget-lua.tmp/
+mkdir -p get-wget-lua.tmp
+
+cd get-wget-lua.tmp
+
+if builtin type -p curl &>/dev/null
+then
+  curl -L $WGET_DOWNLOAD_URL | tar -xj --strip-components=1
+elif builtin type -p wget &>/dev/null
+then
+  wget --output-document=- $WGET_DOWNLOAD_URL | tar -xj --strip-components=1
+else
+  echo "You need Curl or Wget to download the source files."
+  exit 1
+fi
+
+if ./configure $CONFIGURE_SSL_OPT --disable-nls && make && src/wget -V | grep -q lua
+then
+  cp src/wget ../wget-lua
+  cd ../
+  echo
+  echo
+  echo "###################################################################"
+  echo
+  echo "wget-lua successfully built."
+  echo
+  ./wget-lua --help | grep -iE "gnu|warc|lua"
+  rm -rf get-wget-lua.tmp
+  exit 0
+else
+  echo
+  echo "wget-lua not successfully built."
+  echo
+  exit 1
+fi

--- a/get-wget-lua.sh
+++ b/get-wget-lua.sh
@@ -18,7 +18,7 @@ then
   fi
 fi
 
-WGET_DOWNLOAD_URL="http://warriorhq.archiveteam.org/downloads/wget-lua/wget-1.14.lua.LATEST.tar.bz2"
+WGET_DOWNLOAD_URL="https://warriorhq.archiveteam.org/downloads/wget-lua/wget-1.14.lua.LATEST.tar.bz2"
 
 rm -rf get-wget-lua.tmp/
 mkdir -p get-wget-lua.tmp


### PR DESCRIPTION
Motivation here is to support https with wget-lua. Since the wget-lua package doesn't support it, we have to compile it with SSL support. Took the opportunity to update the baseimage at the same time, since we no longer need to depend on an old version to use the wget-lua package.

I did my best to limit resulting image size, it comes out to around 591MB which seems sort of large, but short of changing the base to something like alpine which would require additional work, I don't know how to make it any better.