### PR TITLE
Prevent liblua5.1-0 from being autoremoved

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ CMD ["/sbin/my_init"]
 ADD get-wget-lua.sh /
 
 # Install dependencies
-RUN apt-get update && apt-get install -y python python-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget libgnutls-dev liblua5.1-0-dev autoconf flex \
+RUN apt-get update && apt-get install -y python python-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget libgnutls-dev liblua5.1-0 liblua5.1-0-dev autoconf flex \
  && chmod +x /get-wget-lua.sh && bash -c "/get-wget-lua.sh" \
  && apt-get remove -y libgnutls-dev liblua5.1-0-dev autoconf flex && apt-get clean && apt-get autoremove -y
 


### PR DESCRIPTION
I was trying to figure out why my client was never downloading anything, and it turns out that liblua5.1-0 was being autoremoved on line 15. This caused wget-lua to fail to run.
This change marks liblua5.1-0 as manually installed so wget-lua will work.