### PR TITLE
added example for docker-compose with watchtower.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3"
+
+services:
+  Watchtower:
+    image: v2tec/watchtower:latest
+    command: --cleanup --label-enable --schedule="0 2 * * *"
+    container_name: Watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+    restart: unless-stopped
+
+  archiveTeamWarrior:
+    image: archiveteam/warrior-dockerfile
+    container_name: archiveTeamWarrior
+    hostname: archiveTeamWarrior
+    ports:
+      - "8001:8001"
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+    restart: always
+


### PR DESCRIPTION
added an example for a docker-compose.yml with watchtower, so if there's a new version of the archiveWarrior dockerfile it will reboot and use that instead. 

# how to install docker-compose
https://docs.docker.com/compose/install/

# how to use docker-compose
```bash
docker-compose up -d
```