### PR TITLE
RPi dockerfile updates

### DIFF
--- a/Dockerfile.raspberry
+++ b/Dockerfile.raspberry
@@ -11,8 +11,7 @@ CMD ["/sbin/my_init"]
 
 # Install dependencies
 RUN apt-get update
-RUN apt-get install -y python-pip python3 python3-pip git sudo net-tools isc-dhcp-client python-software-properties wget liblua5.1-0 python-dev
-RUN apt-get clean && apt-get autoremove -y
+RUN apt-get install -y python-pip python3 python3-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget liblua5.1-0 python-dev
 
 # Add wget-lua binary compiled for ARM
 ADD wget-lua.raspberry /usr/bin/wget-lua
@@ -40,4 +39,4 @@ RUN mkdir /etc/service/warrior
 ADD warrior.sh /etc/service/warrior/run
 
 # Clean up APT when done.
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get clean && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile.raspberry
+++ b/Dockerfile.raspberry
@@ -11,7 +11,8 @@ CMD ["/sbin/my_init"]
 
 # Install dependencies
 RUN apt-get update
-RUN apt-get install -y python-pip git sudo net-tools isc-dhcp-client python-software-properties wget liblua5.1-0 python-dev
+RUN apt-get install -y python-pip python3 python3-pip git sudo net-tools isc-dhcp-client python-software-properties wget liblua5.1-0 python-dev
+RUN apt-get clean && apt-get autoremove -y
 
 # Add wget-lua binary compiled for ARM
 ADD wget-lua.raspberry /usr/bin/wget-lua


### PR DESCRIPTION
Add required dependencies (namely `python3` and `pip3`) in `Dockerfile.raspberry`.

Upon building an running `Dockerfile.raspberry` on an RPi Model 2 B, I noticed that most of the current warrior projects were not working correctly. Out of the box, I believe only URLTeam2 and WikiTeam were working... I've since added several dependencies and tested each project. 5 projects are now working that were not before, but several are still showing errors.

# Working Now
- URLTeam
- WikiTeam
- Yahoo Answers (Fixed with this PR)
- Livejournal Discovery (Fixed with this PR)
- Quizlet (Fixed with this PR)
- Wikispaces (Fixed with this PR)
- Zetaboards (Fixed with this PR)

# Still Not Working
- Flickr
- Newsgrabber
- GitHub discovery `[Errno 8] Exec format error` likely ARM is currently an unsupported architecture
- Tindeck `Traceback (most recent call last): File "<string>", line 21, in <module> ImportError: No module named 'warc' During handling of the above exception, another exception occurred: Traceback (most recent call last): File "/home/warrior/warrior-code2/src/seesaw/seesaw/warrior.py", line 737, in start_selected_project pipeline_path, {"downloader": self.downloader}) File "/home/warrior/warrior-code2/src/seesaw/seesaw/warrior.py", line 686, in load_pipeline exec(pipeline_str, local_context, global_context) File "<string>", line 23, in <module> Exception: Please install warc with 'pip install warc --upgrade'.`
- FTPDiscovery `Traceback (most recent call last): File "/home/warrior/warrior-code2/src/seesaw/seesaw/warrior.py", line 737, in start_selected_project pipeline_path, {"downloader": self.downloader}) File "/home/warrior/warrior-code2/src/seesaw/seesaw/warrior.py", line 686, in load_pipeline exec(pipeline_str, local_context, global_context) File "<string>", line 144, in <module> File "<string>", line 138, in get_hash FileNotFoundError: [Errno 2] No such file or directory: '/data/data/projects/ftpdisco-1156c27/CheetoFTP/scanner.py'`
- FTP-GOV Traceback (most recent call last): File "/home/warrior/warrior-code2/src/seesaw/seesaw/warrior.py", line 737, in start_selected_project pipeline_path, {"downloader": self.downloader}) File "/home/warrior/warrior-code2/src/seesaw/seesaw/warrior.py", line 686, in load_pipeline exec(pipeline_str, local_context, global_context) File "<string>", line 55, in <module> Exception: No usable Wpull found.`
- Livejournal WIP (git clone error, tried to clone https://github.com/ArchiveTeam/ instead of the actual repo)

I may have some bandwidth to dig into some of these errors in the next few days and weeks, but either way this merge should be good to go until then as it fixes several projects. If anyone else notices any quick fixes given some of those ^ error messages that would be rad too!

