### PR TITLE
Multiple Raspberry Pi cleanups

### DIFF
--- a/Dockerfile.raspberry
+++ b/Dockerfile.raspberry
@@ -13,13 +13,12 @@ RUN apt-get install -y --no-install-recommends \
 	liblua5.1-0 \
 	python \
 	python-pip \
-	python-requests \
 	python-setuptools \
 	python3 \
 	python3-pip \
-	python3-requests \
 	python3-setuptools \
 	sudo \
+	wget \
 	&& useradd -d /home/warrior -m -U warrior \
 	&& echo "warrior ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
 	&& mkdir -p /data/data \
@@ -61,11 +60,16 @@ RUN apt-get remove -y --purge \
 	&& apt-get clean -y \
 	&& apt-get autoremove -y --purge \
 	&& rm -r /var/lib/apt/lists/* \
-	&& rm -r /tmp
+	&& rm -r /tmp/*
 
-RUN pip3 install seesaw \
+RUN pip install requests \
+	&& pip install six \
 	&& pip install warc \
+	&& pip3 install requests \
+	&& pip3 install six \
 	&& pip3 install warc
+
+RUN pip3 install seesaw
 
 WORKDIR /home/warrior
 USER warrior

--- a/Dockerfile.raspberry
+++ b/Dockerfile.raspberry
@@ -6,25 +6,66 @@ LABEL version="1.0.0" \
 # Install dependencies
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
+	curl \
+	git \
+	net-tools \
+	libgnutls30 \
+	liblua5.1-0 \
 	python \
 	python-pip \
+	python-requests \
 	python-setuptools \
 	python3 \
 	python3-pip \
+	python3-requests \
 	python3-setuptools \
-	git \
-	net-tools \
-	wget \
-	liblua5.1-0 \
-	&& rm -rf /var/lib/apt/lists/* \
+	sudo \
 	&& useradd -d /home/warrior -m -U warrior \
 	&& echo "warrior ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
 	&& mkdir -p /data/data \
 	&& chown -R warrior:warrior /data/data
 
-# Add wget-lua binary compiled for ARM
-COPY wget-lua.raspberry /usr/bin/wget-lua
-RUN pip3 install seesaw
+RUN apt-get install -y --no-install-recommends \
+	autoconf \
+	build-essential \
+	flex \
+	libgnutls28-dev \
+	libidn2-0-dev \
+	uuid-dev \
+	libpsl-dev \
+	libpcre2-dev \
+	liblua5.1-0-dev
+
+WORKDIR /tmp
+RUN curl -o wget-1.14.lua.LATEST.tar.bz2 \
+		https://warriorhq.archiveteam.org/downloads/wget-lua/wget-1.14.lua.LATEST.tar.bz2 \
+	&& tar -jxf /tmp/wget-1.14.lua.LATEST.tar.bz2 \
+		--strip-components=1
+
+RUN ./configure --with-ssl=gnutls --disable-nls \
+	&& make \
+	&& cp src/wget /usr/bin/wget-lua \
+	&& chmod a+x /usr/bin/wget-lua
+
+RUN apt-get remove -y --purge \
+	autoconf \
+	curl \
+	build-essential \
+	flex \
+	libgnutls28-dev \
+	libidn2-0-dev \
+	uuid-dev \
+	libpsl-dev \
+	libpcre2-dev \
+	liblua5.1-0-dev \
+	&& apt-get clean -y \
+	&& apt-get autoremove -y --purge \
+	&& rm -r /var/lib/apt/lists/* \
+	&& rm -r /tmp
+
+RUN pip3 install seesaw \
+	&& pip install warc \
+	&& pip3 install warc
 
 WORKDIR /home/warrior
 USER warrior

--- a/Dockerfile.raspberry
+++ b/Dockerfile.raspberry
@@ -1,42 +1,46 @@
 # Dockerfile for Raspberry Pi 2 and 3
-
-# Use armv7/armhf-baseimage as base image.
-FROM armv7/armhf-baseimage
-
-# Set environment variables.
-ENV HOME /root
-
-# Use baseimage-docker's init system.
-CMD ["/sbin/my_init"]
+FROM arm32v5/debian:sid-slim
+LABEL version="1.0.0" \
+	description="ArchiveTeam Warrior container for Raspberry Pi arm32"
 
 # Install dependencies
 RUN apt-get update
-RUN apt-get install -y python-pip python3 python3-pip git pciutils sudo net-tools isc-dhcp-client python-software-properties wget liblua5.1-0 python-dev
+RUN apt-get install -y --no-install-recommends \
+	python \
+	python-pip \
+	python-setuptools \
+	python3 \
+	python3-pip \
+	python3-setuptools \
+	git \
+	net-tools \
+	wget \
+	liblua5.1-0 \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& useradd -d /home/warrior -m -U warrior \
+	&& echo "warrior ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
+	&& mkdir -p /data/data \
+	&& chown -R warrior:warrior /data/data
 
 # Add wget-lua binary compiled for ARM
-ADD wget-lua.raspberry /usr/bin/wget-lua
+COPY wget-lua.raspberry /usr/bin/wget-lua
+RUN pip3 install seesaw
 
-# Fix dnsmasq bug (see https://github.com/nicolasff/docker-cassandra/issues/8#issuecomment-36922132)
-RUN echo 'user=root' >> /etc/dnsmasq.conf
+WORKDIR /home/warrior
+USER warrior
+RUN mkdir /home/warrior/projects
 
-# Setup system for the warrior
-RUN useradd warrior
-RUN echo "warrior ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-RUN mkdir /home/warrior && chown warrior: /home/warrior
-
-# Clone warrior code
-RUN (cd /home/warrior && sudo -u warrior git clone -b docker https://github.com/ArchiveTeam/warrior-code2.git)
-
-# Add the boot script (this will install the actual warrior on boot)
-RUN mkdir -p /etc/my_init.d
-ADD boot.sh /etc/my_init.d/warrior-boot.sh
+# Expose the persistent data to the host.  This will allow the user
+# to not have to reconfigure the container across runs.
+VOLUME /data/data
+VOLUME /home/warrior/projects/config.json
 
 # Expose web interface port
 EXPOSE 8001
 
-# Add the warrior service entry for runit
-RUN mkdir /etc/service/warrior
-ADD warrior.sh /etc/service/warrior/run
-
-# Clean up APT when done.
-RUN apt-get clean && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ENTRYPOINT ["run-warrior3", \
+	"--projects-dir", "/home/warrior/projects", \
+	"--data-dir", "/data/data", \
+	"--warrior-hq", "http://warriorhq.archiveteam.org", \
+	"--port", "8001", \
+	"--real-shutdown"]

--- a/README.md
+++ b/README.md
@@ -27,3 +27,30 @@ docker run --detach \
 To access the web interface get the container IP from `docker inspect` and point your browser to `http://IP:8001`. If you are running this container on a headless machine, be sure to bind the docker container's port to a port on that machine (e.g. `-p 8001:8001`) so that you can access the web interface on your LAN.
 
 You can stop and resume the Warrior with `docker stop` and `docker start`
+
+
+Raspberry Pi:
+You can build the container with the following command:
+``` shell-interaction
+docker build --rm -t warrior-arm32v5:latest -f Dockerfile.raspberry .
+```
+
+The image needs a place to store the downloaded data as well as its
+configuration.  Say you have a location suitable at /var/local/warrior
+use the command below, otherwise update the data and config.json paths.
+
+First, create an empty config.json if it doesn't exist.  Otherwise when you
+mount the path with docker it will create it as a directory.
+``` shell-interaction
+touch /var/local/warrior/config.json
+```
+
+Now start the container.
+``` shell-interaction
+docker run \
+	--volume /var/local/warrior/data:/data/data \
+	--volume /var/local/warrior/config.json:/home/warrior/projects/config.json \
+	--publish 8001:8001 \
+	--restart always \
+	warrior-arm32v5:latest
+```


### PR DESCRIPTION
Rebase to Debian's arm32v5 sid-slim image, the armhf image does not execute on my Raspeberry Pi 2 B+ running the vanilla Raspberry Pi foundation Raspbian stretch image.  Cleanup the Dockerfile.raspberry in general.  Add documentation that includes mounting volumes for persistent configuration and data storage.  Currently installs seesaw from PyPi but it would be reasonably trivial to clone master instead if that is more palatable.  This is running urlteam2 presently and seems to function.