### PR TITLE
Add rsync to Dockerfile.raspberry.

### DIFF
--- a/Dockerfile.raspberry
+++ b/Dockerfile.raspberry
@@ -19,6 +19,7 @@ RUN apt-get install -y --no-install-recommends \
 	python3-setuptools \
 	sudo \
 	wget \
+	rsync \
 	&& useradd -d /home/warrior -m -U warrior \
 	&& echo "warrior ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
 	&& mkdir -p /data/data \


### PR DESCRIPTION
Lost a few good crawls and a good half an hour to recompile because of a missing rsync binary.