### PR TITLE
Readme - show UI from localhost only

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ docker pull archiveteam/warrior-dockerfile
 # you will need to detach or stop-and-start the container.
 # use -p to bind port 8001 on the docker container
 # (default ip 172.17.0.x) to port 8001 on localhost.
-docker run [-d] [-p 8001:8001] archiveteam/warrior-dockerfile
+docker run [-d] [-p 127.0.0.1:8001:8001] archiveteam/warrior-dockerfile
 ```
 
 If you prefer to just run the process in the background, and automatically start it again after machine reboot, use this instead:
 
 ``` shell-interaction
 docker run --detach \
-  --publish 8001:8001 \
+  --publish 127.0.0.1:8001:8001 \
   --restart always \
   archiveteam/warrior-dockerfile
 ```


### PR DESCRIPTION
This is a nudge for people running this docker image from a VPS, who
should think about restricting access. (I'm running on localhost and
using an ssh tunnel to the vps:
`ssh root@IP_ADDRESS -L 127.0.0.1:8001:127.0.0.1:8001 -N`)

People at home shouldn't notice this change (athough they are probably
safe anyway, because of NAT-ing routers.)