### PR TITLE
fix build dependencies in Dockerfile.raspberry

### DIFF
--- a/Dockerfile.raspberry
+++ b/Dockerfile.raspberry
@@ -14,9 +14,11 @@ RUN apt-get install -y --no-install-recommends \
 	python \
 	python-pip \
 	python-setuptools \
+	python-wheel \
 	python3 \
 	python3-pip \
 	python3-setuptools \
+	python3-wheel \
 	sudo \
 	wget \
 	rsync \
@@ -34,7 +36,8 @@ RUN apt-get install -y --no-install-recommends \
 	uuid-dev \
 	libpsl-dev \
 	libpcre2-dev \
-	liblua5.1-0-dev
+	liblua5.1-0-dev \
+	zlib1g-dev
 
 WORKDIR /tmp
 RUN curl -o wget-1.14.lua.LATEST.tar.bz2 \
@@ -58,6 +61,7 @@ RUN apt-get remove -y --purge \
 	libpsl-dev \
 	libpcre2-dev \
 	liblua5.1-0-dev \
+	zlib1g-dev \
 	&& apt-get clean -y \
 	&& apt-get autoremove -y --purge \
 	&& rm -r /var/lib/apt/lists/* \


### PR DESCRIPTION
The base image for the Raspberry don't have zlib1g-dev or the
Python wheel (python-wheel and python3-wheel) installed.

The first results in a wget-lua that doesn't have zlib support, which
cause an exception upon upload (Exception: Please compile wget with zlib support!),
with an invalid data package uploaded to the server.

The second one doesn't appear to cause any problems, but it doesn't
look pretty when building the image.