### PR TITLE
Update kubernetes deployment YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ docker run \
 
 ## Kubernetes
 
+Edit the environment variable `DOWNLOADER` inside `warrior.yml` and set it to your name. This name will be used on the leaderboards.
+
 ``` shell-interaction
 kubectl create namespace archive
 kubectl apply -n archive -f warrior.yml

--- a/warrior.yml
+++ b/warrior.yml
@@ -31,7 +31,7 @@ spec:
         app: warrior
     spec:
       containers:
-      - image: archiveteam/warrior-dockerfile:latest
+      - image: atdr.meo.ws/archiveteam/warrior-dockerfile:latest
         name: warrior
         resources: {}
         env:

--- a/warrior.yml
+++ b/warrior.yml
@@ -30,27 +30,14 @@ spec:
       labels:
         app: warrior
     spec:
-      volumes:
-      - name: warrior-data
-        emptyDir: {}
       containers:
-      - image: docker.io/kjoconnor/archive-team-warrior:latest
+      - image: archiveteam/warrior-dockerfile:latest
         name: warrior
+        resources: {}
+        env:
+        - name: DOWNLOADER
+          value: kubernetes
+        - name: SELECTED_PROJECT
+          value: auto
         ports:
         - containerPort: 8001
-        volumeMounts:
-        - name: warrior-data
-          mountPath: /home/warrior
-      initContainers:
-        - name: create-dirs
-          image: busybox
-          command: [ "mkdir", "/home/warrior/projects", "/home/warrior/assets" ]
-          volumeMounts:
-          - name: warrior-data
-            mountPath: /home/warrior
-        - name: chmod
-          image: busybox
-          command: [ "chmod", "-R", "777", "/home/warrior" ]
-          volumeMounts:
-          - name: warrior-data
-            mountPath: /home/warrior


### PR DESCRIPTION
The kubernetes "emptydir" mount in /home/warrior/ will overwrite whatever the container brings itself to /home/warrior, including start.py. As a result, the container does not start. 
This patch:
* Removes volumes
* Removes previously required initContainers that were used to setup the volume
* Changes the image address to dockerhub
* Added an empty resources limiter to make the linter happy
* Added required environment variables so that the deployment "just works"