### PR TITLE
Update Dockerfile.raspberry to use debian stable

### DIFF
--- a/Dockerfile.raspberry
+++ b/Dockerfile.raspberry
@@ -1,5 +1,5 @@
 # Dockerfile for Raspberry Pi 2 and 3
-FROM arm32v5/debian:sid-slim
+FROM arm32v5/debian:stable-slim
 LABEL version="1.0.0" \
 	description="ArchiveTeam Warrior container for Raspberry Pi arm32"
 


### PR DESCRIPTION
Fixes #43 by switching to debian:table-slim rather than using debian:sid-slim, which doesn't build correctly.