### PR TITLE
Docker-Compose: Updated Watchtower and persist Warrior config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: "3"
 
 services:
   Watchtower:
-    image: v2tec/watchtower:latest
-    command: --cleanup --label-enable --schedule="0 2 * * *"
+    image: containrrr/watchtower:latest
+    command: --cleanup --label-enable --interval 3600
     container_name: Watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -15,6 +15,8 @@ services:
     image: atdr.meo.ws/archiveteam/warrior-dockerfile
     container_name: archiveTeamWarrior
     hostname: archiveTeamWarrior
+    volumes:
+      - ./config.json:/home/warrior/projects/config.json
     ports:
       - "8001:8001"
     labels:


### PR DESCRIPTION
v2tech is no longer the project steward for Watchtower and their image for Watchtower hasn't been updated in years. Changed to containrr and adjusted the interval to match the Archive Team wiki recommendations.

https://wiki.archiveteam.org/index.php/Running_Archive_Team_Projects_with_Docker

Also made the config file for Warrior persistent so the user doesn't lose their settings.