### PR TITLE
Update docker-compose.yml to use new watchtower

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   Watchtower:
-    image: v2tec/watchtower:latest
+    image: containrrr/watchtower:latest
     command: --cleanup --label-enable --schedule="0 2 * * *"
     container_name: Watchtower
     volumes:


### PR DESCRIPTION
https://hub.docker.com/r/v2tec/watchtower hasn't been pushed in 4 years.

The rest of the repo uses https://hub.docker.com/r/containrrr/watchtower
(including the README).