### PR TITLE
Scope watchtower to just this warrior

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     labels:
       com.centurylinklabs.watchtower.enable: "true"
+      com.centurylinklabs.watchtower.scope: "archive-team-warrior"
     restart: unless-stopped
 
   archiveTeamWarrior:
@@ -18,4 +19,5 @@ services:
       - "8001:8001"
     labels:
       com.centurylinklabs.watchtower.enable: "true"
+      com.centurylinklabs.watchtower.scope: "archive-team-warrior"
     restart: always


### PR DESCRIPTION
The example docker-compose includes a watchtower service. As configured this service would update any containers running on this docker host with the right label. This might be surprising to some people who don't already use watchtower (but may have copy/pasted the watchtower label at some point when reading tutorials/examples).

The fix is to scope the watchtower service in the example docker-compose.yml to just this stack. (Watchtower docs on scoping: https://containrrr.dev/watchtower/running-multiple-instances/)