### PR TITLE
feat: support custom run dir, tmpfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ docker run --detach \
 | SHARED_RSYNC_THREADS | shared:rsync_threads |                   | `20`    |
 | WARRIOR_ID           | warrior_id           |                   |         |
 | CONCURRENT_ITEMS     | concurrent_items     |                   | `3`     |
+| WARRIOR_RUN_DIR      |                      |                   | `/home/warrior` |
 
 ## Other Ways to Run
 
@@ -131,4 +132,16 @@ First edit the `docker-compose.yml` file with any configuration keys (as describ
 ```bash
 cd examples
 docker compose up -d
+```
+
+#### Run using tmpfs
+
+The Warrior uses disk as scratch space. You may want to use a `tmpfs` mount to [prevent unnecessary wear and tear](https://github.com/ArchiveTeam/warrior-dockerfile/issues/83) if you have RAM to spare. Docker Compose example:
+
+```
+  warrior:
+    environment:
+      WARRIOR_RUN_DIR: /warrior-tmp
+    tmpfs:
+      - /warrior-tmp:exec,mode=777,uid=1000,gid=1000
 ```

--- a/start.py
+++ b/start.py
@@ -1,8 +1,18 @@
 import json
 import os
 import subprocess
+import shutil
 
-CONFIG_FILE = 'projects/config.json'
+DEFAULT_RUN_DIR = '/home/warrior'
+WARRIOR_RUN_DIR = os.getenv('WARRIOR_RUN_DIR', DEFAULT_RUN_DIR)
+CONFIG_FILE = os.path.join(WARRIOR_RUN_DIR, 'projects/config.json')
+
+# copy data/projects from image to the custom run dir
+if WARRIOR_RUN_DIR != DEFAULT_RUN_DIR:
+    for dir_name in ['data', 'projects']:
+        dst = os.path.join(WARRIOR_RUN_DIR, dir_name)
+        src = os.path.join(DEFAULT_RUN_DIR, dir_name)
+        shutil.copytree(src, dst)
 
 try:
     with open(CONFIG_FILE, 'r') as fp:
@@ -24,9 +34,9 @@ subprocess.run(
     [
         "run-warrior3",
         "--projects-dir",
-        "/home/warrior/projects",
+        os.path.join(WARRIOR_RUN_DIR, "projects"),
         "--data-dir",
-        "/home/warrior/data",
+        os.path.join(WARRIOR_RUN_DIR, "data"),
         "--warrior-hq",
         "https://warriorhq.archiveteam.org",
         "--port",


### PR DESCRIPTION
This PR makes it possible to change the location of `data` and `projects` when running the Docker warrior. The main change required was to copy the `data` and `projects` directories from the image so that `wget-at`, etc. is still available.

The primary motivation for this change is to [allow running the warrior in tmpfs](https://github.com/ArchiveTeam/warrior-dockerfile/issues/83#issuecomment-2892399223) to prevent unnecessary SSD wear/tear. Personally, over several years of running all AT projects via the Docker warrior, I've written hundreds of unnecessary terabytes to my SSDs. 

Running using `tmpfs` also improves performance, as ramdisk is much faster than SSD or HDD storage.

I'm very open to suggestions to improve this PR and get it merged.

Sample docker-compose.yml to test:

```yaml
services:
  warrior:
    image: ghcr.io/flotwig/warrior-dockerfile:master
    ports:
      - "8001:8001"
    environment:
      WARRIOR_RUN_DIR: /warrior-tmp
    tmpfs:
      - /warrior-tmp:exec,mode=777,uid=1000,gid=1000
```