### PR TITLE
Fix Watchtower Docker API issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ docker run --detach \
   --name watchtower \
   --restart=on-failure \
   --volume /var/run/docker.sock:/var/run/docker.sock \
+  -e DOCKER_API_VERSION=1.52 \
   containrrr/watchtower --label-enable --cleanup --interval 3600
 
 docker run --detach \
@@ -37,6 +38,7 @@ docker run --detach ^
   --name watchtower ^
   --restart=on-failure ^
   --volume /var/run/docker.sock:/var/run/docker.sock ^
+  -e DOCKER_API_VERSION=1.52 ^
   containrrr/watchtower --label-enable --cleanup --interval 3600
 
 docker run --detach ^

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     labels:
       com.centurylinklabs.watchtower.enable: "true"
     restart: unless-stopped
+    environment:
+      - DOCKER_API_VERSION=1.52
 
   archiveTeamWarrior:
     image: atdr.meo.ws/archiveteam/warrior-dockerfile


### PR DESCRIPTION
Watchtower hasn't been maintained in over 2 years. As a result, the project has fallen far behind the Docker API version, and has started failing with the default configuration. Adding the DOCKER_API_VERSION environment variable gets passed the current failures.

However, due to the lack of maintenance to Watchtower, Archive Warrior may want to consider switching to another project. There's no guarantee that Incrementing an environment variable will continue to be a workable solution.